### PR TITLE
Improve errors dialog

### DIFF
--- a/src/main/resources/io/jenkins/plugins/bootstrap5/MessagesViewModel/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/bootstrap5/MessagesViewModel/index.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:bs="/bootstrap5">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:bs="/bootstrap5" xmlns:fa="/font-awesome">
 
   <st:header name="Content-Type" value="text/html;charset=UTF-8"/>
 
@@ -8,19 +8,24 @@
     <j:if test="${size(it.errorMessages) > 0}">
       <div class="row py-3">
         <div class="col">
-          <bs:card title="${%Error Messages}" fontAwesomeIcon="exclamation-triangle">
 
-            <pre>
-              <samp id="errors" class="log-output">
-                <j:forEach var="message" items="${it.errorMessages}">
-                  <div>
-                    ${message}
-                  </div>
-                </j:forEach>
-              </samp>
-            </pre>
-
-          </bs:card>
+          <div class="card">
+            <div class="card-body">
+              <div class="card-title">
+                ${%Error Messages}
+                <fa:svg-icon name="exclamation-triangle" class="icon-right fa-image-button-warning"/>
+              </div>
+              <pre>
+                <samp id="errors" class="log-output">
+                  <j:forEach var="message" items="${it.errorMessages}">
+                    <div>
+                      ${message}
+                    </div>
+                  </j:forEach>
+                </samp>
+              </pre>
+            </div>
+          </div>
         </div>
       </div>
     </j:if>

--- a/src/main/resources/io/jenkins/plugins/bootstrap5/MessagesViewModel/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/bootstrap5/MessagesViewModel/index.jelly
@@ -5,7 +5,7 @@
 
   <bs:page it="${it}">
 
-    <j:if test="${size(errors) > 0}">
+    <j:if test="${size(it.errorMessages) > 0}">
       <div class="row py-3">
         <div class="col">
           <bs:card title="${%Error Messages}" fontAwesomeIcon="exclamation-triangle">

--- a/src/main/webapp/css/jenkins-style.css
+++ b/src/main/webapp/css/jenkins-style.css
@@ -30,14 +30,6 @@ pre {
     font-size: var(--font-size-sm);
 }
 
-.info-page-decorator {
-    fill: #b4b4b4;
-    height: 16px;
-    width: 16px;
-    vertical-align: text-bottom;
-    margin-left: 0.2em;
-}
-
 /* ------------------------------------------------------------------------------------------------------------------- */
 /* Bootstrap Carousel                                                                                                  */
 /* ------------------------------------------------------------------------------------------------------------------- */
@@ -59,7 +51,6 @@ pre {
     font-size: inherit;
 }
 
-
 .card-title {
     font-size: 1.2rem;
     font-weight: 500;
@@ -68,7 +59,7 @@ pre {
 
 .icon-right {
     float: right;
-    fill: #b4b4b4;
+    fill: var(--fa-image-color);
     height: 48px;
     width: 48px;
     position: absolute;


### PR DESCRIPTION
Error messages have not been shown due to a typo in the property. Additionally, the error icon is now shown in Jenkins' warning color.

![Bildschirmfoto 2021-11-20 um 20 58 54](https://user-images.githubusercontent.com/503338/142739412-f08ab76f-a0a4-4316-9770-48710d2599e6.png)
