### PR TITLE
Added an attribute for applying classes to the page-body

### DIFF
--- a/src/main/resources/bootstrap5/page.jelly
+++ b/src/main/resources/bootstrap5/page.jelly
@@ -9,6 +9,10 @@
     <st:attribute name="notitle" use="optional">
       Hide the title on top of the page.
     </st:attribute>
+    <st:attribute name="class" use="optional">
+      Additional classes to be applied to the page body.
+    </st:attribute>
+
   </st:documentation>
 
   <st:header name="Content-Type" value="text/html;charset=UTF-8"/>
@@ -21,7 +25,7 @@
 
       <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
 
-      <div class="fluid-container">
+      <div class="container-fluid ${class}">
 
         <j:if test="${notitle == null}">
           <h1>${title}</h1>


### PR DESCRIPTION
I added an optional attribute which can be used in order to apply additional classes to the page body.
Also, I changed the class `fluid-container` to the Bootstrap 5 class `container-fluid`, since I guess that has been meant here.
