### PR TITLE
Use new Jenkins styles for Boostrap tabs

### DIFF
--- a/src/main/webapp/css/jenkins-style.css
+++ b/src/main/webapp/css/jenkins-style.css
@@ -3,6 +3,10 @@
 /* These styles will only be picked up on Jenkins >=2.239
 /* ------------------------------------------------------------------------------------------------------------------- */
 
+:root {
+    --bs-nav-tabs-border-width: 0;
+}
+
 body {
     background-color: var(--background);
     color: var(--text-color);
@@ -28,6 +32,21 @@ pre {
 
 .log-output {
     font-size: var(--font-size-sm);
+}
+
+/* ------------------------------------------------------------------------------------------------------------------- */
+/* Bootstrap tabs in Jenkins style                                                                                                  */
+/* ------------------------------------------------------------------------------------------------------------------- */
+
+.tabBar {
+    list-style: none;
+}
+
+.tabBar .tab a.active {
+    background: var(--tabs-item-background--selected);
+    color: var(--tabs-item-foreground--selected);
+    cursor: default;
+    z-index: 2;
 }
 
 /* ------------------------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
Use the tab styles from the dashboard and plugin manager for Bootstrap tabs as well.

Light Theme:
![Bildschirmfoto 2022-08-23 um 00 55 58](https://user-images.githubusercontent.com/503338/186033313-dda05621-fcf7-4465-946c-4114b09812f6.png)

Dark Theme:
![Bildschirmfoto 2022-08-23 um 00 56 21](https://user-images.githubusercontent.com/503338/186033341-994bbe65-8030-482c-938e-e0182c0ca53f.png)
