### PR TITLE
[JENKINS-67244] Use Jenkins text and background color in modals

### DIFF
--- a/src/main/webapp/css/jenkins-style.css
+++ b/src/main/webapp/css/jenkins-style.css
@@ -7,6 +7,11 @@
     --bs-nav-tabs-border-width: 0;
 }
 
+.modal {
+    --bs-modal-color: var(--text-color);
+    --bs-modal-bg: var(--background);
+}
+
 body {
     background-color: var(--background);
     color: var(--text-color);


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-67244.

New modal dialog still is not perfectly styled, but at least usable:

![Bildschirmfoto 2022-09-20 um 23 00 40](https://user-images.githubusercontent.com/503338/191363656-2a27fd94-9bca-41df-a11b-fad9aebfb3d2.png)
