### PR TITLE
Fix icon and style of errors card

### DIFF
--- a/src/main/resources/io/jenkins/plugins/bootstrap5/MessagesViewModel/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/bootstrap5/MessagesViewModel/index.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:bs="/bootstrap5" xmlns:fa="/font-awesome">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:bs="/bootstrap5">
 
   <st:header name="Content-Type" value="text/html;charset=UTF-8"/>
 
@@ -9,23 +9,17 @@
       <div class="row py-3">
         <div class="col">
 
-          <div class="card">
-            <div class="card-body">
-              <div class="card-title">
-                ${%Error Messages}
-                <fa:svg-icon name="triangle-exclamation" class="icon-right fa-image-button-warning"/>
-              </div>
-              <pre>
-                <samp id="errors" class="log-output">
-                  <j:forEach var="message" items="${it.errorMessages}">
-                    <div>
-                      ${message}
-                    </div>
-                  </j:forEach>
-                </samp>
-              </pre>
-            </div>
-          </div>
+          <bs:card title="${%Error Messages}" fontAwesomeIcon="triangle-exclamation">
+            <pre>
+              <samp id="errors" class="log-output">
+                <j:forEach var="message" items="${it.errorMessages}">
+                  <div>
+                    ${message}
+                  </div>
+                </j:forEach>
+              </samp>
+            </pre>
+          </bs:card>
         </div>
       </div>
     </j:if>


### PR DESCRIPTION
The layout of all cards has been changed recently, however the errors view has been forgotten.

Before:
<img width="1049" alt="Bildschirmfoto 2022-09-28 um 23 16 00" src="https://user-images.githubusercontent.com/503338/192890587-4b0dee7b-b6bf-4884-9f04-cc17fd9821d0.png">

After:
<img width="1047" alt="Bildschirmfoto 2022-09-28 um 23 16 25" src="https://user-images.githubusercontent.com/503338/192890655-2096fd97-e373-4072-ab85-024768bfe7d0.png">
