### PR TITLE
Support operation without Prototype.js

### DIFF
--- a/src/main/webapp/js/no-prototype.js
+++ b/src/main/webapp/js/no-prototype.js
@@ -1,5 +1,5 @@
 /* global Prototype, jQuery3 */
-if (Prototype.BrowserFeatures.ElementExtensions) {
+if (typeof Prototype === 'object' && Prototype.BrowserFeatures.ElementExtensions) {
     const disablePrototypeJS = function (method, pluginsToDisable) {
         const handler = function (event) {
             event.target[method] = undefined;


### PR DESCRIPTION
I have a local branch where Prototype.js has been removed from core. This plugin does not work on that branch because (ironically) it tries to detect and disable prototype, which fails when Prototype.js is not present. This adds a guard to this logic to only run when Prototype.js is actually present. With this PR I no longer get a stack trace when running on my branch that has Prototype.js removed.