### PR TITLE
Embed Popper.js 2 into Bootstrap plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,15 @@
                     <exclude>*.bundle.*</exclude>
                   </excludes>
                 </resource>
+                <resource>
+                  <directory>${project.basedir}/node_modules/@popperjs/core/dist/umd</directory>
+                  <filtering>false</filtering>
+                  <includes>
+                    <include>popper.js</include>
+                    <include>popper.min.js</include>
+                    <include>popper.min.js.flow</include>
+                  </includes>
+                </resource>
               </resources>
             </configuration>
           </execution>

--- a/src/main/resources/io/jenkins/plugins/bootstrap5.jelly
+++ b/src/main/resources/io/jenkins/plugins/bootstrap5.jelly
@@ -12,6 +12,7 @@ Use it like <st:adjunct includes="io.jenkins.plugins.bootstrap5"/>
   <link type="text/css" rel="stylesheet" href="${resURL}/plugin/bootstrap5-api/css/bootstrap-custom-build.css"/>
   <link type="text/css" rel="stylesheet" href="${resURL}/plugin/bootstrap5-api/css/jenkins-style.css"/>
 
+  <script type="text/javascript" src="${resURL}/plugin/bootstrap5-api/js/popper.min.js"/>
   <script type="text/javascript" src="${resURL}/plugin/bootstrap5-api/js/bootstrap.min.js"/>
   <script type="text/javascript" src="${resURL}/plugin/bootstrap5-api/js/no-prototype.js"/>
 


### PR DESCRIPTION
[Popper 2](https://popper.js.org/) is a dependency for Boostrap. It simplifies the development process if this JS file is included here, making the [Popper API plugin](https://github.com/jenkinsci/popper2-api-plugin) obsolete.  