### PR TITLE
Embed all Popper.js files in Bootstrap plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,11 +110,6 @@
                 <resource>
                   <directory>${project.basedir}/node_modules/@popperjs/core/dist/umd</directory>
                   <filtering>false</filtering>
-                  <includes>
-                    <include>popper.js</include>
-                    <include>popper.min.js</include>
-                    <include>popper.min.js.flow</include>
-                  </includes>
                 </resource>
               </resources>
             </configuration>


### PR DESCRIPTION
Some files were missing in the latest update.