### PR TITLE
Bump version to 5.2.3-x

### DIFF
--- a/etc/bootstrap-custom-build.scss
+++ b/etc/bootstrap-custom-build.scss
@@ -19,6 +19,7 @@ $container-max-widths: (
 ) !default;
 
 @import "../node_modules/bootstrap/scss/variables";
+@import "../node_modules/bootstrap/scss/variables-dark";
 @import "../node_modules/bootstrap/scss/maps";
 @import "../node_modules/bootstrap/scss/mixins";
 @import "../node_modules/bootstrap/scss/utilities";
@@ -54,7 +55,6 @@ th {
 @import "../node_modules/bootstrap/scss/pagination";
 @import "../node_modules/bootstrap/scss/badge";
 @import "../node_modules/bootstrap/scss/alert";
-@import "../node_modules/bootstrap/scss/progress";
 @import "../node_modules/bootstrap/scss/list-group";
 @import "../node_modules/bootstrap/scss/close";
 @import "../node_modules/bootstrap/scss/toasts";

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "node-sass": "^9.0.0"
   },
   "scripts": {
-    "full-build": "npm-run-all build css-rtl css-prefix",
+    "full-build": "npm-run-all node-sass-build build css-rtl css-prefix",
+    "node-sass-build": "npm rebuild node-sass",
     "build": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 etc -o target/bootstrap5-api/css",
     "css-rtl": "cross-env NODE_ENV=RTL postcss --config etc/postcss.config.js --dir \"target/bootstrap5-api/css\" --ext \".rtl.css\" \"target/bootstrap5-api/css/*.css\" \"!target/bootstrap5-api/css/*.min.css\" \"!target/bootstrap5-api/css/*.rtl.css\"",
     "css-prefix": "postcss --config etc/postcss.config.js --replace \"target/bootstrap5-api/css/*.css\" \"!target/bootstrap5-api/css/*.rtl*.css\" \"!target/bootstrap5-api/css/*.min.css\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap5-api",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Bootstrap 5 Jenkins Plugin",
   "directories": {
     "doc": "doc"

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <description>Provides Bootstrap 5 for Jenkins plugins.</description>
 
   <properties>
-    <revision>5.2.2-7</revision>
+    <revision>5.2.3-1</revision>
     <changelist>-SNAPSHOT</changelist>
     <module.name>${project.groupId}.bootstrap5</module.name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,22 @@
         <configuration>
           <filesets>
             <fileset>
+              <directory>./</directory>
+              <includes>
+                <include>package-lock.json</include>
+              </includes>
+            </fileset>
+            <fileset>
               <directory>node</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
             </fileset>
             <fileset>
               <directory>node_modules</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
             </fileset>
           </filesets>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,20 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>node</directory>
+            </fileset>
+            <fileset>
+              <directory>node_modules</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
         <version>1.12.1</version>


### PR DESCRIPTION
Somehow I forgot to keep the plugin release in synch with the bootstrap release. (It was already part of https://github.com/jenkinsci/bootstrap5-api-plugin/releases/tag/v5.2.2-1)

The new releases requires a new import that has been added now. Additionally, to make the build more reliable, all node folders are now deleted and node-sass is rebuilt. 