### PR TITLE
Update npm-run-all to npm-run-all2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cross-env": "7.0.3",
     "rtlcss": "4.1.1",
     "node-sass": "9.0.0",
-    "npm-run-all": "4.1.5",
+    "npm-run-all2": "6.1.1",
     "postcss": "8.4.33",
     "postcss-cli": "11.0.0",
     "remark-cli": "12.0.0",


### PR DESCRIPTION
This PR aims to replace `npm-run-all` which is no longer maintained (https://github.com/mysticatea/npm-run-all - last release November 2018).
The replacement `npm-run-all2` is still actively maintained (https://github.com/bcomnes/npm-run-all2 - last release October 2023)

> npm-run-all2 why?
> 
> A maintenance fork of npm-run-all. npm-run-all2 is a fork of npm-run-all with dependabot updates, release automation enabled and some troublesome babel stuff removed to further reduce maintenance burden. Hopefully this labor can upstream some day when mysticatea returns, but until then, welcome aboard!
> 

### Testing done

Ran `mvn verify` without any issues.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```