### PR TITLE
Fix tabs in 2.496

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <revision>5.3.3-3</revision>
     <changelist>-SNAPSHOT</changelist>
     <module.name>${project.groupId}.bootstrap5</module.name>
-
+    <jenkins.version>2.496</jenkins.version>
   </properties>
 
   <licenses>

--- a/src/main/webapp/css/jenkins-style.css
+++ b/src/main/webapp/css/jenkins-style.css
@@ -62,10 +62,25 @@ pre {
 }
 
 .tabBar .tab a.active {
-    background: var(--tabs-item-background--selected);
-    color: var(--tabs-item-foreground--selected);
-    cursor: default;
     z-index: 2;
+    cursor: default;
+    font-weight: 450;
+    color: var(--tabs-item-foreground--active);
+
+    &::before {
+        background-clip: padding-box;
+        background-color: var(--tabs-item-background--selected) !important;
+        border: var(--jenkins-border--subtle) !important;
+    }
+
+    &::after {
+        display: none;
+    }
+
+    &::before,
+    &::after {
+        inset: 0;
+    }
 }
 
 /* ------------------------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
Bootstrap tabs have different markup in comparison to tabs in `core`. This led to a regression in plugins that use Bootstrap 5 when https://github.com/jenkinsci/jenkins/pull/10198 was merged. The markup in `core` should probably be updated to align with how Bootstrap does it, seeing as that seems to be more semantically correct (but that'd be a much larger change).

**Before**
<img width="443" alt="image" src="https://github.com/user-attachments/assets/c25234f0-9a0d-4ee7-b912-b3128e3b509d" />

**After**
<img width="449" alt="image" src="https://github.com/user-attachments/assets/013a4f5c-6680-4a63-9514-cfb2e022064a" />

Unsure if we want to release for 2.496 and above now, or wait for the next LTS @uhafner 

### Testing done

* Coverage report works as expected

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
