### PR TITLE
Fix carousel arrows color in dark mode

### DIFF
--- a/src/main/webapp/css/jenkins-style.css
+++ b/src/main/webapp/css/jenkins-style.css
@@ -90,6 +90,7 @@ pre {
 .carousel-control-prev, .carousel-control-next {
     width: 15px;
     fill: var(--text-color);
+    filter: none;
 }
 
 /* ------------------------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
The color of these arrowsis set to match text color, but the `inverse` filter coming from Bootstrap makes it black in dark mode.

### Testing done

After:
<img width="391" height="418" alt="image" src="https://github.com/user-attachments/assets/275f7185-3501-4a0e-b4fa-d51034cbb0cb" />
<img width="385" height="425" alt="image" src="https://github.com/user-attachments/assets/a08c3e4d-57fe-4bd4-b281-5e0b90f287ab" />

Before:
<img width="392" height="421" alt="image" src="https://github.com/user-attachments/assets/e86e25f2-dcfe-49dd-8155-ec576b874f0d" />
<img width="386" height="427" alt="image" src="https://github.com/user-attachments/assets/44443dd7-d341-45be-884c-c4b44b34001f" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
