### PR TITLE
Remove body styling

### DIFF
--- a/src/main/webapp/css/jenkins-style.css
+++ b/src/main/webapp/css/jenkins-style.css
@@ -26,11 +26,6 @@
     --bs-modal-bg: var(--background);
 }
 
-body {
-    background-color: var(--background);
-    color: var(--text-color);
-}
-
 .table {
     color: inherit;
 }


### PR DESCRIPTION
Spotted in https://github.com/jenkinsci/jenkins/pull/26863

This plugin overrides the background styling of `body`, which causes the background of the page to be ever so slightly different when changing between pages which use this plugin and those that don't.

### Testing done

### Before

<img width="375" height="212" alt="Screenshot 2026-06-13 at 11 00 36" src="https://github.com/user-attachments/assets/588d0df8-91e0-4e9d-a164-9ee890e9b29a" />

### After

<img width="480" height="189" alt="Screenshot 2026-06-13 at 11 00 57" src="https://github.com/user-attachments/assets/f725afb3-a4d8-4f31-80e8-f58e91f9bf6b" />

_(it's a very subtle difference)_

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
